### PR TITLE
fix bug #7: vim dir created wherever vim is run from

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@
 Create and manage directories to store unique backup, swap, and undo
 files in a centralized place.
 
-Backup, swap, and undo are created in `$VIMHOME` (which defaults to
-`~/.vim` on Unix based systems).
+Backup, swap, and undo are created in `$VIMHOME`, which defaults to
+`$HOME/.vim` on Unix based systems and `$HOME\vimfiles` on Windows
+based systems. This location can be manually overridden by defining
+`$VIMHOME` with your local vimrc file.
 
 ```sh
 $VIMHOME
@@ -32,7 +34,7 @@ let g:central_cleanup_enable = 30
 ```
 
 Vim will also maintain multiple backups each time a file is written
-to. These backup files are saved in `$$VIMHOME/backup` and follow the
+to. These backup files are saved in `$VIMHOME/backup` and follow the
 naming convention `<buffer name>~<original path>~<time stamp>`, thus
 ensuing a unique backup each time the buffer is saved. This can be
 disabled by setting `g:central_multiple_backup_enable` to zero, where
@@ -41,7 +43,7 @@ Vim will only maintain a single backup each time a file is written to.
 let g:central_multiple_backup_enable = 0
 ```
 
-## Installation 
+## Installation
 
 ### [vim-plug](https://github.com/junegunn/vim-plug)
 Add this to your `.vimrc`

--- a/doc/central.txt
+++ b/doc/central.txt
@@ -8,14 +8,16 @@ INTRODUCTION                      *central*
 
 This plugin creates directories to store backup, swap and undo files in a
 centralized place. If these directories do not already exist, Central.vim
-will create them inside your local `$VIMHOME` directory. 
-
+will create them in the local `$VIMHOME` directory (where `$VIMHOME` defaults
+to `$HOME/.vim` on Unix systems and `$HOME\vimfiles` on Windows systems). The
+vaule of `$VIMHOME` can be manually configured by defining it in your local
+vimrc file.
 >
-$VIMHOME
-├── backup
-├── swap
-└── undo
-
+        $VIMHOME
+         ├── backup
+         ├── swap
+         └── undo
+<
 In order for Vim to take advantage of these new directories Central.vim 
 configures their location.
 >
@@ -30,7 +32,6 @@ to any duration in days, or set to zero to disable auto deletion.
 >
 	let g:central_cleanup_enable = 30 "days
 <
-
 This plugin also maintain multiple backups each time a file is written
 to. These backup files are saved in `$$VIMHOME/backup` and follow the
 naming convention `<buffer name>~<original path>~<time stamp>`, thus

--- a/plugin/central.vim
+++ b/plugin/central.vim
@@ -4,6 +4,14 @@
 " Version: 0.2.0
 " License: BSD
 
+if !exists('$VIMHOME')
+    if has('win32') || has ('win64')
+        let $VIMHOME=$HOME.'/vimfiles'
+    else
+        let $VIMHOME=$HOME.'/.vim'
+    endif
+endif
+
 set backupdir=$VIMHOME/backup//
 set directory=$VIMHOME/swap//
 set undodir=$VIMHOME/undo//


### PR DESCRIPTION
The `$VIMHOME` variable is not defined by Vim itself, instead it is
something that I have defined in my personal vimrc file. This patch
resolves this issue by defining `$VIMHOME` within this plugin. Note
that it will not redefine `$VIMHOME` if it already exists; allowing
the user to manually configure their own location to store the back
up files if they so wish.