### PR TITLE
improve startup time by running fs commands async

### DIFF
--- a/plugin/central.vim
+++ b/plugin/central.vim
@@ -43,7 +43,11 @@ function! CheckDirectories(timer)
     endif
 endfunction
 
-call timer_start(20, 'CheckDirectories')
+if has('timers')
+    call timer_start(20, 'CheckDirectories')
+else
+    call CheckDirectories(1)
+endif
 
 if !exists('g:central_multiple_backup_enable')
     let g:central_multiple_backup_enable = 1

--- a/plugin/central.vim
+++ b/plugin/central.vim
@@ -1,7 +1,7 @@
 " central.vim - Centralize Swap, Backup, Undo
 " Author: Melanie Berkley <http://berkley.io>
 " Collaborator: Matthew Bright <https://github.com/matt1003/>
-" Version: 0.2.0
+" Version: 0.2.1
 " License: BSD
 
 if !exists('$VIMHOME')

--- a/plugin/central.vim
+++ b/plugin/central.vim
@@ -44,7 +44,7 @@ function! CheckDirectories(timer)
 endfunction
 
 if has('timers')
-    call timer_start(20, 'CheckDirectories')
+    call timer_start(0, 'CheckDirectories')
 else
     call CheckDirectories(1)
 endif


### PR DESCRIPTION
I ran `vim --startuptime` and found this plugin takes up a noticeable amount of time on vim start

```
202.658  124.741  124.741: sourcing /Users/fent/.vim/plugged/central.vim/plugin/central.vim
```

for me, that can be as high as 250ms. it's dependent on how many files there are in the directories. this patch uses a timer to run those filesystem commands that normally run on vim load asynchronously.

this is the `vim --startuptime` after the patch

```
067.417  000.149  000.149: sourcing /Users/fent/.vim/plugged/central.vim/plugin/central.vim
```