### PR TITLE
cleanup `backupext` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ let g:central_cleanup_enable = 30
 
 Vim will also maintain multiple backups each time a file is written
 to. These backup files are saved in `$VIMHOME/backup` and follow the
-naming convention `<buffer name>~<original path>~<time stamp>`, thus
+naming convention `<original path>~<time stamp>`, thus
 ensuing a unique backup each time the buffer is saved. This can be
 disabled by setting `g:central_multiple_backup_enable` to zero, where
 Vim will only maintain a single backup each time a file is written to.

--- a/plugin/central.vim
+++ b/plugin/central.vim
@@ -56,9 +56,6 @@ endif
 if g:central_multiple_backup_enable == 1
     augroup CentralMultipleBackup
         autocmd!
-        autocmd BufWritePre *
-        \   let s:path = substitute(expand('%:p:h'),'/','%','g')
-        \ | let s:time = strftime("%Y-%m-%d~%H:%M:%S")
-        \ | let &backupext = '~'.s:path.'~'.s:time
+        autocmd BufWritePre * let &backupext = '~'.strftime("%Y-%m-%d~%H:%M:%S")
     augroup END
 endif


### PR DESCRIPTION
no need to include the path in the `backupext` option, as it is already included when using `//` in `backupdir`

from:
https://vimhelp.org/options.txt.html#:~:text=For%20Unix%20and%20Win32%2C%20if%20a%20directory%20ends%20in%20two%20path%20separators%20%22//%22%2C%0A%09%20%20the%20backup%20file%20name%20will%20be%20built%20from%20the%20complete%20path%20to%20the%0A%09%20%20file%20with%20all%20path%20separators%20changed%20to%20percent%20%27%25%27%20signs.

![image](https://user-images.githubusercontent.com/933490/224517670-05702213-4c8b-4332-af8e-cbd2e722b286.png)

my motivation to fix this was that one of my file's paths was so long it was causing an error when trying to save. this change doesn't fix that error, but mitigates it with no downside. theoretically, you could still create a filepath just below the path length limit, and go over it since you'd be prepending `$HOME/.vim/backup/` to it.