### PR TITLE
Support for Neovim

### DIFF
--- a/plugin/central.vim
+++ b/plugin/central.vim
@@ -5,7 +5,9 @@
 " License: BSD
 
 if !exists('$VIMHOME')
-    if has('win32') || has ('win64')
+    if has('nvim')
+        let $VIMHOME=stdpath('data')
+    elseif has('win32') || has ('win64')
         let $VIMHOME=$HOME.'/vimfiles'
     else
         let $VIMHOME=$HOME.'/.vim'


### PR DESCRIPTION
Use `stdpath('data')` as the default `$VIMHOME` when running Neovim.